### PR TITLE
Potential fix for code scanning alert no. 2: Database query built from user-controlled sources

### DIFF
--- a/src/controllers/indexController.js
+++ b/src/controllers/indexController.js
@@ -29,7 +29,10 @@ const nameQuery = async (req, res) => {
             return res.status(422).json({ message: "No organization number provided" });
         }
 
-        const exactMatchQuery = brreg.findOne({ navn: name }).limit(5);
+        if (typeof name !== "string") {
+            return res.status(400).json({ message: "Invalid name provided" });
+        }
+        const exactMatchQuery = brreg.findOne({ navn: { $eq: name } }).limit(5);
 
         const similarMatchQuery = brreg.findOne(
             { $text: { $search: name } },


### PR DESCRIPTION
Potential fix for [https://github.com/chrwiencke/FastBrreg/security/code-scanning/2](https://github.com/chrwiencke/FastBrreg/security/code-scanning/2)

To fix the problem, we need to ensure that the user-provided `name` parameter is treated as a literal value in the MongoDB query. This can be achieved by using the `$eq` operator in the query. Additionally, we should validate that the `name` parameter is a string before using it in the query.

1. Modify the query to use the `$eq` operator to ensure the `name` parameter is treated as a literal value.
2. Add a check to ensure the `name` parameter is a string before using it in the query.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
